### PR TITLE
ENG-0000: add asset group topology preview endpoint

### DIFF
--- a/packages/assets-query/package.json
+++ b/packages/assets-query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/assets-query",
-  "version": "2.1.18",
+  "version": "2.1.19",
   "license": "MIT",
   "description": "A client for interacting with the Alert Logic Assets Query Public API",
   "author": {

--- a/packages/assets-query/src/al-assets-query-client.ts
+++ b/packages/assets-query/src/al-assets-query-client.ts
@@ -21,7 +21,7 @@ import {
     AssetsQueryParams,
     AssetQueryGeneralResponse,
 } from './types';
-import { AssetGroup, AssetGroupPayload } from './types/assets/asset-groups';
+import { AssetGroup, AssetGroupPayload, AssetGroupTopologyResponse, Scope } from './types/assets/asset-groups';
 
 export class AlAssetsQueryClientInstance {
 
@@ -444,5 +444,21 @@ export class AlAssetsQueryClientInstance {
       version: this.serviceVersion,
       data: payload
     });
+  }
+
+  /**
+   * Get Asset Group Topology
+   * POST
+   * /assets_query/v1/:account_id/topology/asset_group
+   */
+  async getAssetGroupTopology(accountId: string, scopes: Scope[]): Promise<AssetGroupTopologyResponse> {
+    return this.client.post<AssetGroupTopologyResponse>({
+        service_stack: AlLocation.InsightAPI,
+        account_id: accountId,
+        service_name: 'assets_query',
+        path: 'topology/asset_group',
+        version: this.serviceVersion,
+        data: {scopes}
+      });
   }
 }

--- a/packages/assets-query/src/types/assets/asset-groups.ts
+++ b/packages/assets-query/src/types/assets/asset-groups.ts
@@ -44,3 +44,54 @@ export interface AssetGroup {
     deleted_on: number;
     modified_on: number;
 }
+
+export interface AssetGroupTopologyResponse {
+    topology: AssetGroupTopology;
+}
+
+export interface AssetGroupTopology {
+    assets: string[][];
+    data: { [property: string]: TopologyAssetData };
+    rows: number;
+}
+
+// TODO - May be better to define an asset interface per asset type rather than merge all possible fields to a single interface
+// These fields should be enough for now for POC asset group work
+export interface TopologyAssetData {
+    account_id?: string;
+    alertlogic_appliance?: boolean;
+    architecture?: string;
+    availability_zone?: string;
+    cidr_block?: string;
+    created_on?: number;
+    deployment_id?: string;
+    dns_name?: string;
+    groups?: string[];
+    group_name?: string;
+    group_membership?: string;
+    group_id?: string;
+    instance_id?: string;
+    instance_name?: string;
+    instance_type?: string;
+    ip_address?: string;
+    key?: string;
+    launch_time?: number;
+    modified_on?: number;
+    name?: string;
+    native_type?: string;
+    private_dns_name?: string;
+    private_ip_address?: string;
+    private_ip_addresses?: string[];
+    private_ipv4_addresses?: string[];
+    private_ipv6_addresses?: string[];
+    public_ip_addresses?: string;
+    public_ipv4_addresses?: string[];
+    public_ipv6_addresses?: string[];
+    state?: string;
+    subnet_id?: string;
+    subnet_name?: string;
+    subnet_uuid?: string;
+    tags?: { [property: string]: string };
+    type?: string;
+
+}


### PR DESCRIPTION
Adding support for the new preview topology endpoint for asset groups - https://console.account.product.dev.alertlogic.com/users/api/assets_query/index.html#api-Topology-GetAssetGroupTopology