### PR TITLE
ENG-18993: @al/assets-query - update asset group implementations

### DIFF
--- a/packages/assets-query/package.json
+++ b/packages/assets-query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/assets-query",
-  "version": "2.1.28",
+  "version": "2.1.29",
   "license": "MIT",
   "description": "A client for interacting with the Alert Logic Assets Query Public API",
   "author": {

--- a/packages/assets-query/src/al-assets-query-client.ts
+++ b/packages/assets-query/src/al-assets-query-client.ts
@@ -29,7 +29,7 @@ import {
     AssetGroupTopologyResponse,
     Scope
 } from './types/assets/asset-groups';
-import { AssetTypesListResponse, AssetTypesResponse } from './types/assets/asset-types';
+import { AssetTypesListResponse, AssetTypesResponse, DeleteAssetGroupResponse } from './types/assets/asset-types';
 
 export class AlAssetsQueryClientInstance {
 
@@ -500,6 +500,27 @@ export class AlAssetsQueryClientInstance {
         path: 'asset_types',
         version: this.serviceVersion,
         params: queryParams,
+      });
+  }
+
+  /**
+   * Delete Asset Group
+   * PUT
+   * /assets_query/v1/:account_id/asset_groups
+   */
+  async deleteAssetGroup(accountId: string, name: string, dryRun = false) {
+    return this.client.put<DeleteAssetGroupResponse>({
+        service_stack: AlLocation.InsightAPI,
+        account_id: accountId,
+        service_name: 'assets_query',
+        path: 'asset_groups',
+        version: this.serviceVersion,
+        data: {
+            name,
+            operation: 'delete_asset_group',
+            scope : 'user',
+            dry_run: dryRun
+        }
       });
   }
 }

--- a/packages/assets-query/src/types/assets/asset-groups.ts
+++ b/packages/assets-query/src/types/assets/asset-groups.ts
@@ -24,13 +24,14 @@ export interface Properties {
 }
 
 export interface AssetGroupPayload {
-    key: string;
-    operation: 'create_asset_group' | "delete_asset_group" | "update_asset_group";
-    scope: string;
-    name: string;
+    key?: string;
+    operation?: 'create_asset_group' | "delete_asset_group" | "update_asset_group";
+    scope?: string;
+    name?: string;
     criticality?: number;
     description?: string;
     properties?: Properties;
+    dry_run?: boolean;
 }
 
 export interface AssetGroup {
@@ -86,6 +87,10 @@ export interface TopologyAssetData {
     ip_address?: string;
     key?: string;
     launch_time?: number;
+    membership_counts?: { [property: string]: {
+        in?: number;
+        not_in?: number
+    } };
     modified_on?: number;
     name?: string;
     native_type?: string;

--- a/packages/assets-query/src/types/assets/asset-types.ts
+++ b/packages/assets-query/src/types/assets/asset-types.ts
@@ -31,3 +31,11 @@ export interface AssetTypesListResponse {
     unscoped_properties: string[];
     vulnerable: boolean;
 }
+
+export interface DeleteAssetGroupResponse {
+    dry_run: boolean;
+    operations: {
+        operation: string;
+        name: string;
+    }[];
+}

--- a/packages/assets-query/src/types/index.ts
+++ b/packages/assets-query/src/types/index.ts
@@ -350,6 +350,9 @@ export interface AssetQueryResultItem {
     groups_match?: 'any' | 'all';
     in_scope?: boolean;
     key?: string;
+    membership_counts?: {
+        [property: string]: number;
+    };
     modified_on?: number;
     name?: string;
     native_type?: string;


### PR DESCRIPTION
### ENG-18993

https://alertlogic.atlassian.net/browse/ENG-18993

- Updating delete operation for asset groups in line with latest API updates 
  - See https://console.account.alertlogic.com/users/api/assets_query/#api-AssetGroupOperations-DeleteAssetGroup