### PR TITLE
ENG-24176 - adding reelaborateIncidentStatus endpoint to Iris service

### DIFF
--- a/packages/iris/package.json
+++ b/packages/iris/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/iris",
-  "version": "2.0.23",
+  "version": "2.0.24",
   "license": "MIT",
   "description": "A client for interacting with the Alert Logic Iris Public API",
   "author": {

--- a/packages/iris/src/al-iris-client.ts
+++ b/packages/iris/src/al-iris-client.ts
@@ -708,6 +708,27 @@ export class AlIrisClientInstance {
     }
 
     /**
+     * Reelaboration status from a incident
+     * GET /iris/v3/{cid}/reelaboration_status/{request_id}
+     * @param accountId account id
+     * @param requestId request id
+     */
+    async reelaborateIncidentStatus(
+        accountId: string,
+        requestId: string,
+    ): Promise<unknown> {
+        return this.client.get<unknown>(
+            {
+                service_stack: AlLocation.InsightAPI,
+                service_name: this.serviceName,
+                version: 'v3',
+                account_id: accountId,
+                path: `/reelaboration_status/${requestId}`,
+            }
+        );
+    }
+
+    /**
      * Get the elaborations that are not flagged
      * @param accountId account id
      * @param incidentId incident id

--- a/packages/iris/src/types/additional-evidence-types.ts
+++ b/packages/iris/src/types/additional-evidence-types.ts
@@ -3,8 +3,5 @@ export interface AdditionalEvidenceRequest {
 }
 
 export interface AdditionalEvidenceResponse {
-  fields: {
-    get_additional_evidence: boolean,
-    reelaborate: boolean
-  };
+  request_id: string;
 }


### PR DESCRIPTION
US: [ENG-24176](https://alertlogic.atlassian.net/browse/ENG-24176?atlOrigin=eyJpIjoiZTA0MDhmMDdjNjE2NGVkNTk5N2ZmZmU4NGE2ZWVlMTMiLCJwIjoiaiJ9)