### PR TITLE
ENG-29759: fix limit param nonsense on playbooks fetch

### DIFF
--- a/packages/responder/package.json
+++ b/packages/responder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/responder",
-  "version": "1.0.60",
+  "version": "1.0.61",
   "license": "MIT",
   "description": "A lightweight client library for interacting with the Automatic Responder API",
   "author": {
@@ -14,10 +14,6 @@
     "Responder"
   ],
   "maintainers": [
-    {
-      "name": "Maryit Sanchez",
-      "email": "msanchez@alertlogic.com"
-    },
     {
       "name": "Alert Logic NPM Team",
       "email": "npm@alertlogic.com"

--- a/packages/responder/src/al-responder-client.ts
+++ b/packages/responder/src/al-responder-client.ts
@@ -102,8 +102,8 @@ export class AlResponderClientInstance {
         let marker = undefined;
 
         const staticParams = {
-            ...parameters,
             ...{ limit: 100 },
+            ...parameters
         };
 
         do {


### PR DESCRIPTION
Fixing an issue where supplied limit params are being overwritten by default value in spread operator, just a simple ordering fix! 