### PR TITLE
ENG-0000: implement new undispose endpoint from service

### DIFF
--- a/packages/assets-query/package.json
+++ b/packages/assets-query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/assets-query",
-  "version": "2.1.44",
+  "version": "2.1.45",
   "license": "MIT",
   "description": "A client for interacting with the Alert Logic Assets Query Public API",
   "author": {

--- a/packages/assets-query/src/al-assets-query-client.ts
+++ b/packages/assets-query/src/al-assets-query-client.ts
@@ -26,6 +26,7 @@ import {
   FoundAsset,
   GenericResponse,
   RemediationsItemsListResponse,
+  UndisposeRemediationsRequestBody,
 } from './types';
 import {
   AssetGroup,
@@ -365,7 +366,7 @@ export class AlAssetsQueryClientInstance {
   async disposeRemediations(accountId: string, remediationData: {
     deployment_ids?: string[], filters: string[] | string[][],
     vulnerability_ids?: string[], remediation_ids?: string[], reason: string,
-    comment: string, expires?: number, applies_to_specific_assets?: boolean
+    comment: string, expires?: number, applies_to_specific_assets?: boolean, filter_match_mode?: string
   }): Promise<RemediationsItemsListResponse> {
     let baseRemediationData = { operation: 'dispose_remediations' };
     Object.assign(baseRemediationData, remediationData);
@@ -400,6 +401,7 @@ export class AlAssetsQueryClientInstance {
 
   /**
    * Undispose Remediations
+   * @deprecated use undisposeRemediationItems insetad.
    * DELETE
    * /remediations/v1/:account_id/remediations
    * https://api.cloudinsight.alertlogic.com/remediations/v1/12345678/remediations?remediation_item_ids=0536575B914C32C8A5D28415D02E4545"
@@ -415,6 +417,19 @@ export class AlAssetsQueryClientInstance {
       path: '/remediations',
       params: queryParams,
       version: 'v2'
+    });
+  }
+
+  async undisposeRemediationItems(accountId: string, remediationData: UndisposeRemediationsRequestBody): Promise<RemediationsItemsListResponse> {
+    let baseRemediationData: UndisposeRemediationsRequestBody = { operation: 'undispose_remediations' };
+    Object.assign(baseRemediationData, remediationData);
+    return this.client.put<RemediationsItemsListResponse>({
+      service_stack: AlLocation.InsightAPI,
+      account_id: accountId,
+      service_name: 'assets_query',
+      path: 'remediations',
+      version: 'v2',
+      data: baseRemediationData,
     });
   }
 
@@ -489,7 +504,7 @@ export class AlAssetsQueryClientInstance {
   async concludeRemediations(accountId: string,
     remediationData: {
       deployment_ids?: string[], filters: string[] | string[][], vulnerability_ids?: string[],
-      remediation_ids?: string[], applies_to_specific_assets?: boolean
+      remediation_ids?: string[], applies_to_specific_assets?: boolean, filter_match_mode?: string
     }): Promise<RemediationsItemsListResponse> {
     let baseRemediationData = { operation: 'conclude_remediations' };
     Object.assign(baseRemediationData, remediationData);

--- a/packages/assets-query/src/types/index.ts
+++ b/packages/assets-query/src/types/index.ts
@@ -299,6 +299,7 @@ export interface RemediationItemAsset {
     expires?: number;
     exposures?: ExposureQueryResultItem[];
     exposures_count?: number;
+    filter_match_mode?: string;
     filters?: string[];
     item_id?: string;
     item_ids?: string[];
@@ -402,3 +403,14 @@ export interface RemediationsItemsListResponse {
     assets?: GenericResponse[];
     rows?: number;
 }
+
+export interface UndisposeRemediationsRequestBody {
+    operation?: string;
+    filters?: string[];
+    audit_ids?: string[];
+    deployment_ids?: string[];
+    vulnerability_ids?: string[];
+    remediation_ids?: string[];
+    remediation_item_ids?: string[];
+}
+


### PR DESCRIPTION
- Implementing new PUT variation of undispose remediation-items endpoint, to be used in favour of the DELETE endpoint (now marked as deprecated)
- Added new filter_match_mode param to dispose and conclude operation implementations