### PR TITLE
ENG-31262 - Incident evolution should display when only evolves_to

### DIFF
--- a/packages/iris/package.json
+++ b/packages/iris/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/iris",
-  "version": "2.0.34",
+  "version": "2.0.35",
   "license": "MIT",
   "description": "A client for interacting with the Alert Logic Iris Public API",
   "author": {

--- a/packages/iris/src/types/incident.class.ts
+++ b/packages/iris/src/types/incident.class.ts
@@ -95,6 +95,7 @@ interface IncidentProperties {
             alphaId?: string;
             friendlyId: string;
             incidentId: string;
+            threatRating: string;
         }[];
         tree: {
             escalated?: boolean;


### PR DESCRIPTION
[ENG-31262](https://alertlogic.atlassian.net/browse/ENG-31262)
Info: first part create propiedad:threatRating

Make sure we display evolution table even for those incidents that only has "evolved_to"

Make sure that Threat Rating column is displayed for "evolved_to" incidents

URL Example :https://console.incidents.product.dev.alertlogic.com/#/incidents/134260824/detail/613B7641-0001-0020-0002-4F8600000000?aaid=134260824&locid=defender-us-ashburn&tab=evidence

Before

![image](https://user-images.githubusercontent.com/89416874/133338597-d99fe7a5-bd6a-4222-8951-9a353bc56460.png)


After 

![image](https://user-images.githubusercontent.com/89416874/133338627-7385eb15-007f-4b28-a3af-b10bfc3b253b.png)

