### PR TITLE
VTT-3766 Add Region to AlAssetScopeItem type

### DIFF
--- a/packages/applications/package.json
+++ b/packages/applications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/applications",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "license": "MIT",
   "description": "A lightweight client library for interacting with the applications API",
   "author": {

--- a/packages/applications/src/types/index.ts
+++ b/packages/applications/src/types/index.ts
@@ -57,7 +57,7 @@ export interface AlApplicationScope {
 }
 
 export interface AlAssetScopeItem {
-    type: 'deployment' | 'vpc' | 'subnet' | 'host';
+    type: 'deployment' | 'vpc' | 'subnet' | 'host' | 'region';
     key: string;
 }
 


### PR DESCRIPTION
[VTT-3766](https://alertlogic.atlassian.net/browse/VTT-3766)

Adding "Region" string in type to fix VTT-3766