### PR TITLE
ENG-36804: Updating validateIp endpoint due to recently backend changes

### DIFF
--- a/packages/scan-scheduler/package.json
+++ b/packages/scan-scheduler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/scan-scheduler",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "license": "MIT",
   "description": "A client for interacting with the Alert Logic Scan Scheduler Public API",
   "author": {

--- a/packages/scan-scheduler/src/al-scan-scheduler-client.v2.ts
+++ b/packages/scan-scheduler/src/al-scan-scheduler-client.v2.ts
@@ -117,13 +117,13 @@ export class AlScanSchedulerClientInstanceV2 {
      *  This API always returns 200 OK status and provides the results of validation using two arrays with respective status (valid/invalid).
      *  IP Addresses that are present in the valid list can be subsequently used as applicable ScanScopeItems.
      */
-    async validateIp(accountId: string, deploymentId: string, ips: string[]): Promise<AlIPValidationResult> {
+    async validateIp(accountId: string, deploymentId: string, ips: string[], typeOfScan:AlScanSchedule.TypeOfScanEnum='vulnerability'): Promise<AlIPValidationResult> {
         return AlDefaultClient.post({
             service_stack: AlLocation.InsightAPI,
             service_name: this.serviceName,
             version:      2,
             account_id:   accountId,
-            path:         `/${deploymentId}/ip_validator`,
+            path:         `/${deploymentId}/ip_validator/${typeOfScan}`,
             data:         ips
         });
     }


### PR DESCRIPTION
Please check updated API docs:
- [https://algithub.pd.alertlogic.net/defender/scan_scheduler/blob/integration/doc/scheduler.v2.yaml#L162](https://algithub.pd.alertlogic.net/defender/scan_scheduler/blob/integration/doc/scheduler.v2.yaml#L162)

more details in:
[https://alertlogic.atlassian.net/browse/ENG-36804](https://alertlogic.atlassian.net/browse/ENG-36804)