### PR TITLE
ENG-39428 - Add user description for IDS whitelist

### DIFF
--- a/packages/exclusions/package.json
+++ b/packages/exclusions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/exclusions",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "license": "MIT",
   "description": "A lightweight client library for interacting with the Exclusions API",
   "author": {

--- a/packages/exclusions/src/types/index.ts
+++ b/packages/exclusions/src/types/index.ts
@@ -11,6 +11,7 @@ export class ExclusionsRulesDescriptor {
     public blackouts: ExclusionsBlackouts[] = [];
     public assets: ExclusionsAssets[] = [];
     public details?: ExlusionsDetails[] = [];
+    public modified?: ExclusionsModified[] = [] ;
 
     constructor() {
     }
@@ -48,6 +49,10 @@ export class ExclusionsRulesDescriptor {
             for (let i = 0; i < rawData.details.length; i++) {
                 exclusion.details.push(rawData.details[i].hasOwnProperty('feature') ? ExlusionsDetails.import(rawData.details[i]) : new ExlusionsDetails());
             }
+        }
+
+        if (typeof (rawData?.modified) === 'object') {
+            exclusion.modified.push((rawData.modified.hasOwnProperty('at') || rawData.modified.hasOwnProperty('by')) ? ExclusionsModified.import(rawData.modified) : new ExclusionsModified());
         }
 
         return exclusion;
@@ -212,6 +217,29 @@ export class ExlusionsDetails {
         return detail;
     }
 
+}
+
+export class ExclusionsModified {
+
+    at?: number;
+    by?: string;
+
+    constructor() { }
+
+    public static import(rawData: any): ExclusionsModified {
+
+        let modified = new ExclusionsModified();
+
+        if (rawData.hasOwnProperty('at')) {
+            modified.at = rawData.at;
+        }
+
+        if (rawData.hasOwnProperty('by')) {
+            modified.by = rawData.by;
+        }
+
+        return modified;
+    }
 }
 
 export class ExclusionsRulesSnapshot {


### PR DESCRIPTION
[ENG-39428](https://alertlogic.atlassian.net/browse/ENG-39428)

Description: add support for mapping the user in configuration network IDS exclusion

![image](https://user-images.githubusercontent.com/89416874/168901151-e4b62825-1888-4cfa-ac84-de8f071e61b5.png)
![image](https://user-images.githubusercontent.com/89416874/168901451-8edfe7c1-4c7d-4165-bf20-7198a99ea656.png)
