### PR TITLE
ENG-40092 - [UI] safeguard for 'related' property if not coming from API

### DIFF
--- a/packages/iris/package.json
+++ b/packages/iris/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/iris",
-  "version": "2.0.48",
+  "version": "2.0.49",
   "license": "MIT",
   "description": "A client for interacting with the Alert Logic Iris Public API",
   "author": {

--- a/packages/iris/src/types/incident.class.ts
+++ b/packages/iris/src/types/incident.class.ts
@@ -424,7 +424,7 @@ export class Incident {
 
                         // test this in production with
                         // /#/incidents/10785703/ea11106d32f14546/recommendations?aaid=10785703&locid=defender-us-denver
-                        if (i.assetDeploymentInScope) {
+                        if (i.assetDeploymentInScope && host.hasOwnProperty('related')) {
                             Object.entries(host.related)
                                   .filter(([key, value]) => ['auto-scaling-group', 'image', 'load-balancer', 'network-interface', 'sg', 'subnet'].includes(
                                       key))

--- a/packages/iris/src/types/incident.class.ts
+++ b/packages/iris/src/types/incident.class.ts
@@ -424,6 +424,8 @@ export class Incident {
 
                         // test this in production with
                         // /#/incidents/10785703/ea11106d32f14546/recommendations?aaid=10785703&locid=defender-us-denver
+
+                        // only try this if API is returning  the 'related' property for the host 
                         if (i.assetDeploymentInScope && host.hasOwnProperty('related')) {
                             Object.entries(host.related)
                                   .filter(([key, value]) => ['auto-scaling-group', 'image', 'load-balancer', 'network-interface', 'sg', 'subnet'].includes(


### PR DESCRIPTION
Some incidents types have no `host.related` property.
right now the UI is crashing with a JS exception:
https://console.incidents.product.dev.alertlogic.com/#/incidents/134248568/detail/6290F5CE-0002-0120-0002-678A00000000?aaid=2&locid=defender-us-denver&source=logreview&tab=investigation&timeframe=86400&subtab=audit_log
![Screen Shot 2022-05-31 at 10 16 42 AM](https://user-images.githubusercontent.com/5596173/171208794-fe2e87f0-6820-4c93-955b-5b1949efbb31.png)

this fix will allow rendering those incidents that has no `host-related` property:
![Screen Shot 2022-05-31 at 10 21 11 AM](https://user-images.githubusercontent.com/5596173/171209773-055d22e5-1802-4f7b-a034-5573ed8268a6.png)

