### PR TITLE
ENG-40505 - Add responder limits from backend

### DIFF
--- a/packages/responder/package.json
+++ b/packages/responder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/responder",
-  "version": "1.0.100",
+  "version": "1.0.101",
   "license": "MIT",
   "description": "A lightweight client library for interacting with the Automatic Responder API",
   "author": {

--- a/packages/responder/src/al-responder-client.ts
+++ b/packages/responder/src/al-responder-client.ts
@@ -23,6 +23,7 @@ import {
     AlResponderInquiries,
     AlResponderInquiry,
     AlResponderInspectorError,
+    AlResponderLimits,
     AlResponderManageBlockStatusRequest,
     AlResponderMRAWSSNS,
     AlResponderMRAWSWAF,
@@ -1468,6 +1469,24 @@ export class AlResponderClientInstance {
             data: requestBody,
             params: params,
             path: `/managed_response`
+        });
+    }
+
+    /**
+     * Get limits for the creation of paybooks, tasks, triggers, simple responses and exclusions
+     * GET
+     * /v1/{account_id}/limits
+     * https://responder.mdr.global.alertlogic.com
+     * @param accountId {string} AIMS Account ID
+     * @returns {Promise<AlResponderLimits>}
+     */
+    async getLimits(accountId: string, type: string): Promise<AlResponderLimits> {
+        return this.client.get({
+            version: this.serviceVersion,
+            target_endpoint: this.targetEndpoint,
+            service_stack: this.serviceStack,
+            account_id: accountId,
+            path: `/limits`
         });
     }
 }

--- a/packages/responder/src/types/playbookTypes.ts
+++ b/packages/responder/src/types/playbookTypes.ts
@@ -815,3 +815,14 @@ export interface AlManagedResponsePayload {
     };
     target_account_id?: string;
 }
+
+export interface AlResponderLimitContent {
+    max_count: number;
+    count: number;
+}
+
+export interface AlResponderLimits {
+    limits: {
+        mr_configs: AlResponderLimitContent
+    };
+}


### PR DESCRIPTION
# Responder

## User Story
[ENG-40505](https://alertlogic.atlassian.net/browse/ENG-40505)

## Description
Adding types and function to call the endpoint of the limits from responder API