### PR TITLE
ENG-40838 -  change time range dropdown from months to weeks for ESX …

### DIFF
--- a/packages/tacoma/package.json
+++ b/packages/tacoma/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/tacoma",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "license": "MIT",
   "description": "A client for interacting with the Alert Logic Tacoma Public API",
   "author": {

--- a/packages/tacoma/src/types/index.ts
+++ b/packages/tacoma/src/types/index.ts
@@ -17,7 +17,7 @@ export interface AlTacomaView {
     schedule_frequency?: string[] | false;
     parent_account_only?: boolean;
     report_format?: string[];
-    run_once_time_ranges?: string[];
+    run_once_time_ranges?: AlRunOnceTimeRanges[];
     allowed_schedule_hours?: {
         to: number;
         from: number;
@@ -64,4 +64,9 @@ export interface AlSavedView {
     id:             string;
     name:           string;
     embed_url:      string;
+}
+
+export interface AlRunOnceTimeRanges {
+    type: string;
+    timeframes: number;
 }


### PR DESCRIPTION
[ENG-40838](https://alertlogic.atlassian.net/browse/ENG-40838)

Description: adjust the new property, this it's the new type:

**Before:** 
run_once_time_ranges :
[ "weekly" ]

**After:**
run_once_time_ranges :
[
    {
        "type": "weekly",
        "timeframes": 12
    }
]

![image](https://user-images.githubusercontent.com/89416874/181263807-9f190526-c50e-48d8-a779-6d4ade1a4edc.png)
