### PR TITLE
ENG-40838 -  change time range dropdown from months to weeks for ESX …

### DIFF
--- a/packages/tacoma/package.json
+++ b/packages/tacoma/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/tacoma",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "license": "MIT",
   "description": "A client for interacting with the Alert Logic Tacoma Public API",
   "author": {


### PR DESCRIPTION
[ENG-40838](https://alertlogic.atlassian.net/browse/ENG-40838)
Description: adjust the new property, this it's the new type:

- **Before:**

run_once_time_ranges :
[ "weekly" ]

- **After:**

run_once_time_ranges :
[
{
"type": "weekly",
"timeframes": 12
}
]