### PR TITLE
ENG-0000 - Removed obsolete ALClient

### DIFF
--- a/packages/endpoints/package.json
+++ b/packages/endpoints/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/endpoints",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "An API Client for the Alert Logic EEP product backend.",
   "scripts": {
     "test": "karma start",

--- a/packages/endpoints/src/al-endpoints-client.ts
+++ b/packages/endpoints/src/al-endpoints-client.ts
@@ -1,5 +1,4 @@
 import {
-  AIMSClient,
   AIMSOrganization,
   AlDefaultClient,
   AlLocation,
@@ -19,11 +18,25 @@ export class AlEndpointsClientInstance {
 
     constructor() {}
 
+    /**
+     * Retrieve linked organization
+     */
+    async getAccountOrganizationFromAIMS( accountId:string ):Promise<AIMSOrganization> {
+        const requestDescriptor = {
+            service_stack: AlLocation.InsightAPI,
+            service_name: 'aims',
+            version: 1,
+            account_id: accountId,
+            path: '/organization'
+        };
+        return await AlDefaultClient.get<AIMSOrganization>( requestDescriptor );
+    }
+
     public async getAccountOrganization( accountId:string ):Promise<AIMSOrganization> {
         if ( this.organizationMap.hasOwnProperty( accountId ) ) {
             return this.organizationMap[accountId];
         }
-        let organization = await AIMSClient.getAccountOrganization( accountId );
+        let organization = await this.getAccountOrganizationFromAIMS( accountId );
         this.organizationMap[accountId] = organization;
         return organization;
     }

--- a/packages/endpoints/test/al-endpoints-client.spec.ts
+++ b/packages/endpoints/test/al-endpoints-client.spec.ts
@@ -1,5 +1,4 @@
 import {
-  AIMSClient,
   AIMSOrganization,
   AlDefaultClient,
   AlLocation,
@@ -48,7 +47,7 @@ describe('Endpoints API Client', () => {
                 .returns( Promise.resolve({}) );
         lookupDefaultServiceEndpointStub = sinon.stub(AlDefaultClient, 'lookupDefaultServiceEndpoint')
                 .returns( 'https://api.endpoints.product.dev.alertlogic.com' );
-        getOrgStub = sinon.stub( AIMSClient, 'getAccountOrganization' )
+        getOrgStub = sinon.stub( endpointsClient, 'getAccountOrganizationFromAIMS' )
                 .returns( Promise.resolve( organizationMock ) );
         apiBaseURL = AlLocatorService.resolveURL( AlLocation.InsightAPI );
         endpointsApiURL = AlLocatorService.resolveURL( AlLocation.EndpointsAPI );
@@ -61,7 +60,7 @@ describe('Endpoints API Client', () => {
         lookupDefaultServiceEndpointStub.restore();
     });
     describe('dereferencing an account to an organization', () => {
-        it('should use the AIMSClient.getAccountOrganization method and cache results', async() => {
+        it('should use the getAccountOrganizationFromAIMS method and cache results', async() => {
             let organization = await endpointsClient.getAccountOrganization( accountIdMock );
             expect( organization ).to.equal( organizationMock );
             await endpointsClient.getAccountOrganization( accountIdMock );

--- a/packages/otis/package.json
+++ b/packages/otis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/otis",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "license": "MIT",
   "description": "A client for interacting with the Alert Logic OTIS Public API",
   "author": {

--- a/packages/otis/src/otis-client.ts
+++ b/packages/otis/src/otis-client.ts
@@ -1,7 +1,7 @@
 /**
  * A client for interacting with the Alert Logic OTIS Public API.
  */
-import { ALClient, AlLocation } from '@al/core';
+import { AlDefaultClient, AlLocation } from '@al/core';
 
 export interface TuningOptionScope {
   deployment_id?: string;
@@ -21,7 +21,7 @@ export interface TuningOption {
 
 class OTISClient {
 
-  private client = ALClient;
+  private client = AlDefaultClient;
   private serviceName = 'otis';
   private version = 'v3';
   /**

--- a/packages/suggestions/package.json
+++ b/packages/suggestions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/suggestions",
-  "version": "2.0.21",
+  "version": "2.0.22",
   "license": "MIT",
   "description": "A client for interacting with the Alert Logic Suggestions API",
   "author": {

--- a/packages/suggestions/src/suggestions-client.ts
+++ b/packages/suggestions/src/suggestions-client.ts
@@ -2,7 +2,7 @@
  * Module to deal with available Suggestions Public API endpoints
  */
 import {
-    ALClient,
+    AlDefaultClient,
     APIRequestParams,
     AlLocation,
 } from '@al/core';
@@ -29,7 +29,7 @@ import {
 
 export class AlSuggestionsClientInstanceV1 {
 
-    private client = ALClient;
+    private client = AlDefaultClient;
     private serviceName = 'suggestions';
 
     /**


### PR DESCRIPTION
Cleaned up a few lingering references to ALClient (now AlDefaultClient). Also imported an AIMS method into the endpoints client to avoid an unnecessary dependency.