### PR TITLE
ENG-49531: Tuning client endpoints and test fix

### DIFF
--- a/packages/aecontent/package.json
+++ b/packages/aecontent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/aecontent",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "license": "MIT",
   "description": "A client for interacting with the Alert Logic Aecontent Public API",
   "author": {

--- a/packages/aecontent/src/aecontent-client.ts
+++ b/packages/aecontent/src/aecontent-client.ts
@@ -1,4 +1,5 @@
 import { AlApiClient, AlDefaultClient, AlLocation } from '@al/core';
+import { AlTuningRule } from './types/aecontent-client-tuning.type';
 
 export class AecontentClientInstance {
     private serviceName = 'aecontent';
@@ -19,6 +20,60 @@ export class AecontentClientInstance {
             path: `/observations/paths/${path}`,
             version: 'v1',
             params: { ts: timestamp }
+        });
+    }
+
+    /**
+     * create Tuning rule
+     * POST
+     *
+     * @param accountId string tuning rule's belonging account id
+     *
+     */
+    public async createRule(accountId: string, data: AlTuningRule): Promise<any> {
+        return this.client.post<any>({
+            data,
+            service_name: this.serviceName,
+            path: `${accountId}/tunings`,
+            version: 'v1'
+        });
+    }
+
+    /**
+     * delete Tuning rule
+     * DELETE
+     *
+     * @param accountId string tuning rule's belonging account id
+     * @param name string tuning rule's name
+     *
+     */
+    public async deleteRule(accountId: string, name: string): Promise<any> {
+        return this.client.get<any>({
+            service_name: this.serviceName,
+            path: `${accountId}/tunings`,
+            version: 'v1',
+            params: {
+                        ruleName: name
+                    }
+        });
+    }
+
+    /**
+     * Get Tuning rule
+     * GET
+     *
+     * @param accountId string tuning rule's belonging account id
+     * @param name string tuning rule's name
+     *
+     */
+    public async getRule(accountId: string, name: string): Promise<any> {
+        return this.client.get<any>({
+            service_name: this.serviceName,
+            path: `${accountId}/tunings`,
+            version: 'v1',
+            params: {
+                        ruleName: name
+                    }
         });
     }
 }

--- a/packages/aecontent/src/index.ts
+++ b/packages/aecontent/src/index.ts
@@ -2,6 +2,7 @@ import { AlGlobalizer } from '@al/core';
 import { AecontentClientInstance } from './aecontent-client';
 
 export * from './aecontent-client';
+export * from './types';
 
 /**
  * Nothing is complete without at least two aliases

--- a/packages/aecontent/src/types/aecontent-client-tuning.type.ts
+++ b/packages/aecontent/src/types/aecontent-client-tuning.type.ts
@@ -1,0 +1,18 @@
+export interface AlTuningRule {
+    name: string;
+    description?: string;
+    tuning: AlTuningDetails;
+}
+
+export interface AlTuningDetails {
+    type: string;
+    selector: AlTuningOptionDetails;
+    rules: AlTuningOptionDetails[];
+    actions: AlTuningOptionDetails[];
+}
+
+export interface AlTuningOptionDetails {
+    func: string;
+    args: string[];
+}
+

--- a/packages/aecontent/src/types/index.ts
+++ b/packages/aecontent/src/types/index.ts
@@ -1,0 +1,1 @@
+export * from './aecontent-client-tuning.type';

--- a/packages/aecontent/test/aecontent-client.spec.ts
+++ b/packages/aecontent/test/aecontent-client.spec.ts
@@ -21,4 +21,18 @@ describe('Aecontent Client Test Suite:', () => {
         });
     });
 
+    describe('when using tuning endpoint ', () => {
+        let stub: sinon.SinonSpy;
+        beforeEach(() => {
+            stub = sinon.stub(AecontentClient.client, 'get');
+        });
+        afterEach(() => {
+            stub.restore();
+        });
+        it('should call getRule() on the AlDefaultClient instance', async () => {
+            await AecontentClient.getRule('1234', 'fakeRule');
+            expect(stub.callCount).to.equal(1);
+        });
+    });
+
 });


### PR DESCRIPTION
US: [ENG-49531](https://alertlogic.atlassian.net/browse/ENG-49531)

Updating Aecontent client endpoints to work with the new [tuning API](https://algithub.pd.alertlogic.net/pages/alertlogic/aecontent/api/index.html#api-Tuning_Resources-CreateTuning)