### PR TITLE
ENG-51357: Fixing query to not use a global request

### DIFF
--- a/packages/aecontent/package.json
+++ b/packages/aecontent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/aecontent",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "license": "MIT",
   "description": "A client for interacting with the Alert Logic Aecontent Public API",
   "author": {

--- a/packages/aecontent/src/aecontent-client.ts
+++ b/packages/aecontent/src/aecontent-client.ts
@@ -29,9 +29,10 @@ export class AecontentClientInstance {
      *
      * @param path string observation path
      */
-    public async getObservationByPath(path: string): Promise<any> {
+    public async getObservationByPath(accountId: string, path: string): Promise<any> {
         return this.client.get<any>({
             service_name: this.serviceName,
+            account_id: accountId,
             path: `/observations/paths/${path}`,
             version: 'v1',
         });


### PR DESCRIPTION
US: [ENG-51357](https://alertlogic.atlassian.net/browse/ENG-51357)