### PR TITLE
Eng-51696: improving Topology's summary count

### DIFF
--- a/packages/assets-query/package.json
+++ b/packages/assets-query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/assets-query",
-  "version": "2.1.84",
+  "version": "2.1.85",
   "license": "MIT",
   "description": "A client for interacting with the Alert Logic Assets Query Public API",
   "author": {

--- a/packages/assets-query/src/types/assets/phoenix-topology-snapshot.class.ts
+++ b/packages/assets-query/src/types/assets/phoenix-topology-snapshot.class.ts
@@ -125,14 +125,16 @@ export class PhoenixTopologySnapshot {
         ['region', 'vpc', 'subnet', 'host',
          'load-balancer', 'image', 'sg',
          'container', 'tag', 'agent'].forEach(type => {
-                if (assetCounts.hasOwnProperty(type) && type === 'subnet') {
-                    summary['subnets'] = assetCounts['subnet']['standard'] || assetCounts['subnet']['all'];
+                if (type === 'agent') {
+                    summary['agents'] = assetCounts?.['host']?.['agent'] ?? 0;
+                } else if (assetCounts.hasOwnProperty(type) && type === 'subnet') {
+                    summary['subnets'] = assetCounts?.['subnet']?.['standard'] ?? assetCounts?.['subnet']?.['all'] ?? 0;
                 } else if (assetCounts.hasOwnProperty(type) && type !== 'host') {
                     summary[`${type}s`] = assetCounts[type];
                 } else if (assetCounts.hasOwnProperty(type) && type === 'host') {
-                    summary['running_hosts'] = assetCounts['host']['running'];
-                    summary['all_hosts'] = assetCounts['host']['all'];
-                    summary['appliances'] = assetCounts['host'].hasOwnProperty('appliance') ? assetCounts['host']['appliance'] : 0;
+                    summary['running_hosts'] = assetCounts?.['host']?.['running'] ?? 0;
+                    summary['all_hosts'] = assetCounts?.['host']?.['all'] ?? 0;
+                    summary['appliances'] = assetCounts?.['host']?.['appliance'] ?? 0;
                 } else if (!assetCounts.hasOwnProperty(type) && type === 'host') {
                     summary['running_hosts'] = 0;
                     summary['all_hosts'] = 0;
@@ -141,7 +143,6 @@ export class PhoenixTopologySnapshot {
                     summary[`${type}s`] = 0;
                 }
             });
-
         return summary;
     }
 


### PR DESCRIPTION
Changing the value of the agents count. Instead of using "summary.agent" we will use "summary.host.agent"
<img width="1788" alt="image" src="https://github.com/alertlogic/nepal-client-libs/assets/9306084/d3529dd6-d9e3-4174-af1b-01c868681fda">

<img width="579" alt="image" src="https://github.com/alertlogic/nepal-client-libs/assets/9306084/31f8ac26-f2c1-4d96-bc57-64d57a07ad97">
